### PR TITLE
bugfix/APPS-2703 — speed up departments & devices neighbor query

### DIFF
--- a/src/containers/parameters/ParametersReducer.js
+++ b/src/containers/parameters/ParametersReducer.js
@@ -36,7 +36,6 @@ const {
   DONE_LOADING_AGENCIES,
   AGENCY_OPTIONS,
   DEVICE_OPTIONS,
-  DEVICES_BY_AGENCY,
   REVERSE_GEOCODED_COORDS
 } = SEARCH_PARAMETERS_FIELDS;
 
@@ -95,7 +94,6 @@ const INITIAL_STATE :Map<> = fromJS({
   [DONE_LOADING_AGENCIES]: false,
   [AGENCY_OPTIONS]: Map(),
   [DEVICE_OPTIONS]: Map(),
-  [DEVICES_BY_AGENCY]: Map(),
   [REVERSE_GEOCODED_COORDS]: Map()
 });
 
@@ -115,8 +113,7 @@ function reducer(state :Map<> = INITIAL_STATE, action :Object) {
         REQUEST: () => state.set(IS_LOADING_AGENCIES, true).set(DONE_LOADING_AGENCIES, false),
         SUCCESS: () => state
           .set(AGENCY_OPTIONS, action.value.departmentOptions)
-          .set(DEVICE_OPTIONS, action.value.deviceOptions)
-          .set(DEVICES_BY_AGENCY, action.value.devicesByAgency),
+          .set(DEVICE_OPTIONS, action.value.deviceOptions),
         FINALLY: () => state.set(IS_LOADING_AGENCIES, false).set(DONE_LOADING_AGENCIES, true)
       });
     }

--- a/src/containers/parameters/SearchParameters.js
+++ b/src/containers/parameters/SearchParameters.js
@@ -59,7 +59,6 @@ type Props = {
   isDrawMode :boolean;
   agencyOptions :Map<*>;
   deviceOptions :Map<*>;
-  devicesByAgency :Map<*>;
   isLoadingResults :boolean;
   isLoadingNeighbors :boolean;
   reportVehicles :Set<*>;
@@ -438,22 +437,15 @@ class SearchParameters extends React.Component<Props, State> {
   renderFullSearchParameters() {
     const {
       actions,
-      searchParameters,
-      isLoadingAddresses,
-      isDrawMode,
-      noAddressResults,
       agencyOptions,
       deviceOptions,
-      devicesByAgency
+      isDrawMode,
+      isLoadingAddresses,
+      noAddressResults,
+      searchParameters,
     } = this.props;
 
-    let filteredDeviceOptions = deviceOptions;
     const agencyId = searchParameters.get(PARAMETERS.DEPARTMENT);
-    if (agencyId) {
-      const devicesForAgency = devicesByAgency.get(agencyId, List());
-      filteredDeviceOptions = deviceOptions.filter((_, deviceId) => devicesForAgency.includes(deviceId));
-    }
-
     const onAgencyChange = (value) => {
       if (value !== agencyId) {
         actions.updateSearchParameters({ field: PARAMETERS.DEPARTMENT, value });
@@ -655,7 +647,7 @@ class SearchParameters extends React.Component<Props, State> {
                     value={searchParameters.get(PARAMETERS.DEVICE)}
                     onSelect={(value) => actions.updateSearchParameters({ field: PARAMETERS.DEVICE, value })}
                     onClear={() => actions.updateSearchParameters({ field: PARAMETERS.DEVICE, value: '' })}
-                    options={filteredDeviceOptions}
+                    options={deviceOptions}
                     short />
               </InputGroup>
             </Row>
@@ -867,7 +859,6 @@ function mapStateToProps(state :Map<*, *>) :Object {
     isTopNav: !params.get(SEARCH_PARAMETERS.DISPLAY_FULL_SEARCH_OPTIONS),
     agencyOptions: params.get(SEARCH_PARAMETERS.AGENCY_OPTIONS),
     deviceOptions: params.get(SEARCH_PARAMETERS.DEVICE_OPTIONS),
-    devicesByAgency: params.get(SEARCH_PARAMETERS.DEVICES_BY_AGENCY),
 
     reportVehicles: report.get(REPORT.VEHICLE_ENTITY_KEY_IDS)
   };


### PR DESCRIPTION
- Only fetch the department and device entities using `getEntitySetData` instead of finding the device neighbors of departments
- Remove filtering of devices based on selected agency from Search Parameters (because we're removing the neighbors query)

`getEntitySetData` takes only 1 second per request vs. 15 mins for the `searchEntityNeighborsWithFilter` query. Even fetching the device neighbors for 1 single department EKID takes 15 mins.


<img width="1668" alt="Screen Shot 2021-01-26 at 6 12 47 PM" src="https://user-images.githubusercontent.com/32921059/105933236-f154ce00-6002-11eb-8bc1-0ef7c218b5e9.png">
